### PR TITLE
Cap typescript below v7 in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,11 @@
     {
       "groupName": "all",
       "matchManagers": ["github-actions", "npm", "nvm"]
+    },
+    {
+      "description": "TypeScript 7 ships without a programmatic API, so svelte-check and typescript-eslint cannot support it yet. Revisit when TypeScript 7.1 ships that API. See https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/",
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<7"
     }
   ]
 }


### PR DESCRIPTION
## Why

`typescript@7` is unsatisfiable in this repo, and because every manager is grouped into a single `"all"` PR, it takes the whole group down with it. That is what broke #1899 — all three CI jobs plus the Cloudflare Pages build.

Renovate can't resolve it against SvelteKit's peer range, so it never regenerates the lockfile:

```
npm error peerOptional typescript@"^5.3.3 || ^6.0.0" from @sveltejs/kit@2.70.1
```

`package.json` then asks for versions the stale lockfile doesn't have, and `npm ci` refuses:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json are in sync
```

## It isn't just a stale peer range

Forcing TS 7 in with `--legacy-peer-deps` still fails. `npm run lint:check`:

```
Error: typescript-eslint does not support TS 7.0.
```

and `npm run check` crashes inside svelte-check (`Cannot read properties of undefined (reading 'useCaseSensitiveFileNames')`).

Root cause is upstream and singular: **TypeScript 7.0 shipped without a programmatic JS API.** Per [Microsoft's GA announcement](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/), which names Svelte directly:

> TypeScript 7.0 does not ship with an API. We expect TypeScript 7.1 to ship with a new (and different) API.

> Workflows that use Vue, MDX, Astro, Svelte, and others will likely not yet be able to leverage TypeScript 7.

## Why cap rather than close the PR

Closing #1899 would make Renovate ignore *every* major in the `"all"` group, not just typescript. A targeted `allowedVersions` cap lets the rest of the group resolve and merge while typescript stays put.

Verified locally on Node 26 — with the other three updates and typescript held at v6, `npm test` (10/10), `lint:check`, `format:check`, and `check` (240 files, 0 errors) all pass.

## When to revisit

When TypeScript 7.1 ships the new API — no date announced, and there's no 7.1 iteration plan issue yet. Downstream tools then have to port to it. The SvelteKit team closed their own typescript@7 Renovate PR for this exact reason ([sveltejs/kit#16351](https://github.com/sveltejs/kit/pull/16351)).

Upstream trackers: [typescript-eslint#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940) (locked, "nothing we can do") · [language-tools#3063](https://github.com/sveltejs/language-tools/issues/3063) (open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)